### PR TITLE
fix SHOW TABLES

### DIFF
--- a/dbcooper/tests/conftest.py
+++ b/dbcooper/tests/conftest.py
@@ -8,7 +8,7 @@ params_backend = [
     pytest.param(lambda: SqlBackend("mysql"), id = "mysql", marks=pytest.mark.mysql),
     pytest.param(lambda: SqlBackend("sqlite"), id = "sqlite", marks=pytest.mark.sqlite),
     pytest.param(lambda: BigqueryBackend("bigquery"), id = "bigquery", marks=pytest.mark.bigquery),
-    pytest.param(lambda: BigqueryBackend("snowflake"), id = "snowflake", marks=pytest.mark.snowflake),
+    pytest.param(lambda: CloudBackend("snowflake"), id = "snowflake", marks=pytest.mark.snowflake),
     ]
 
 @pytest.fixture(params=params_backend, scope = "session")


### PR DESCRIPTION
fixes #8.

Retrieves the name of the Snowflake connection's database (`db`), and adjusts the `SHOW TABLES` queries to include `IN DATABASE` or `IN ACCOUNT`, depending on if a default database has been provided.

Used a new boolean, `default_db_set`, to handle the logic for determining both the `in_clause` ("database" or "account") and whether to include a database in the calls to `TableName`.

Tested this out on an account that exhibited the bug outlined #8, and confirmed this PR alleviated the issue.