### PR TITLE
fix: correctly omit database in AccessorHierarchyBuilder

### DIFF
--- a/dbcooper/finder.py
+++ b/dbcooper/finder.py
@@ -158,10 +158,10 @@ class AccessorHierarchyBuilder(AccessorBuilder):
             acc_db[schema] = sub_accessors
 
         if self.omit_database:
-            if len(acc_db) != 1:
+            if len(res) != 1:
                 raise ValueError(
                     "Omitting database requires exactly 1 database entry, but found "
-                    f"the following: {list(acc_db)}"
+                    f"the following: {list(res)}"
                 )
 
             # return the only entry in the accessors dictionary


### PR DESCRIPTION
This PR fixes the AccessorHierarchyBuilder, when it is set to omit the database in the table accessor. Previously, if there were multiple schemas, it erroneously believed there were multiple databases, and raised an error.